### PR TITLE
Add string representation of matrices and vectors

### DIFF
--- a/pygraphblas/matrix.py
+++ b/pygraphblas/matrix.py
@@ -1085,6 +1085,22 @@ class Matrix:
             return
         raise TypeError('Unknown index or value for matrix assignment.')
 
+    def to_string(self, format_string='{:>2}', empty_char=''):
+        header = format_string.format('') + ' ' + ''.join(format_string.format(i) for i in range(self.ncols))
+        result = header + '\n'
+        for row in range(self.nrows):
+            result += format_string.format(row) + '|'
+            for col in range(self.ncols):
+                try:
+                    value = self[row, col]
+                except:
+                    value = empty_char
+                result += format_string.format(value)
+            result += '|' + format_string.format(row) + '\n'
+        result += header
+
+        return result
+
     def __repr__(self):
         return '<Matrix (%sx%s : %s:%s)>' % (
             self.nrows,

--- a/pygraphblas/vector.py
+++ b/pygraphblas/vector.py
@@ -624,5 +624,18 @@ class Vector:
         except NoValue:
             return False
 
+    def to_string(self, format_string='{:>2}', empty_char=''):
+        result = ''
+        format_string = format_string + '|' + format_string + '\n'
+
+        for i in range(self.size):
+            try:
+                value = self[i]
+            except:
+                value = empty_char
+            result += format_string.format(i, value)
+
+        return result
+
     def __repr__(self):
         return '<Vector (%s: %s)>' % (self.size, self.nvals)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -1,6 +1,7 @@
 import sys
 from operator import mod
 from itertools import product, repeat
+import re
 
 import pytest
 
@@ -763,6 +764,10 @@ def test_pow():
 def test_T():
     m = Matrix.dense(UINT8, 10, 10)
     assert m.T == m.transpose()
+
+def test_to_string():
+    M = Matrix.from_lists(*(map(list, zip((0, 1, 10), (1, 0, 11)))))
+    assert re.search('-.*10.*\n.*11.*-', M.to_string(empty_char='-'))
 
 # def test_complex():
 #     m = Matrix.from_type(Complex, 10, 10)

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -1,6 +1,7 @@
 import sys
 from itertools import repeat
 from array import array
+import re
 
 from pygraphblas import *
 
@@ -275,3 +276,6 @@ def test_contains():
     assert 9 in v
     assert 10 not in v
 
+def test_to_string():
+    v = Vector.from_lists(*(map(list, zip((0, 10), (2, 11)))))
+    assert re.search('10.*\n.*-.*\n.*11', v.to_string(empty_char='-'))


### PR DESCRIPTION
With @attilanagy234 we wrote a small code to display matrices and vectors.
```python
A = Matrix.from_lists(
    [0, 0, 1, 3, 3, 4, 1, 5],
    [1, 3, 2, 4, 5, 2, 5, 4],
    [9, 3, 8, 6, 1, 4, 7, 2],)
print(A.to_string())
print()
print(A[0].to_string())
```
```
    0 1 2 3 4 5
 0|   9   3    | 0
 1|     8     7| 1
 2|            | 2
 3|         6 1| 3
 4|     4      | 4
 5|         2  | 5
    0 1 2 3 4 5

 0|  
 1| 9
 2|  
 3| 3
 4|  
 5|  
```