### PR TITLE
Check descriptor in Matrix.transpose

### DIFF
--- a/pygraphblas/matrix.py
+++ b/pygraphblas/matrix.py
@@ -312,9 +312,11 @@ class Matrix:
     def transpose(self, out=None, **kwargs):
         """ Transpose matrix. """
         if out is None:
+            new_dimensions = (self.nrows, self.ncols) if TransposeA in kwargs.get('desc', ()) \
+                else (self.ncols, self.nrows)
             _out = ffi.new('GrB_Matrix*')
             _check(lib.GrB_Matrix_new(
-                _out, self.type.gb_type, self.ncols, self.nrows))
+                _out, self.type.gb_type, *new_dimensions))
             out = self.__class__(_out, self.type)
         mask, semiring, accum, desc = self._get_args(**kwargs)
         _check(lib.GrB_transpose(

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -247,13 +247,16 @@ def test_matrix_transpose():
     v = Matrix.from_lists(
         list(range(2, -1, -1)),
         list(range(3)),
-        list(range(3)))
+        list(range(3)),
+        nrows=3, ncols=4)
     w = v.transpose()
     assert w.iseq(Matrix.from_lists(
         [0, 1, 2],
         [2, 1, 0],
-        [0, 1, 2]
-        ))
+        [0, 1, 2],
+        nrows=4, ncols=3))
+    v2 = v.transpose(desc=descriptor.TransposeA)
+    assert v2.iseq(v)
 
 #@pytest.mark.skip
 def test_matrix_mm_read_write(tmp_path):


### PR DESCRIPTION
Enable the use of `TransposeA` descriptor in `Matrix.transpose` and add test.
Previously it caused error:
```py
from pygraphblas import *
from pygraphblas.demo.gviz import draw, draw_op

A = Matrix.from_lists(
    [0, 0, 1],
    [0, 2, 1],
    [1, 2, 3],
    )

print(A.to_string())
print(A.transpose(desc=descriptor.TransposeA).to_string())
```
```
    0 1 2
 0| 1   2| 0
 1|   3  | 1
    0 1 2

---------------------------------------------------------------------------
DimensionMismatch                         Traceback (most recent call last)
<ipython-input-30-5fa90b3f4a8b> in <module>
      9 
     10 print(A.to_string())
---> 11 print(A.transpose(desc=descriptor.TransposeA).to_string())

~/pygraphblas/matrix.py in transpose(self, out, **kwargs)
    323             accum,
    324             self.matrix[0],
--> 325             desc
    326             ))
    327         return out

~/pygraphblas/base.py in _check(res)
    111 def _check(res):
    112     if res != lib.GrB_SUCCESS:
--> 113         raise _error_codes[res](ffi.string(lib.GrB_error()))
    114 
    115 def _check_no_val_key_error(res):

DimensionMismatch: b'GraphBLAS error: GrB_DIMENSION_MISMATCH\nfunction: GrB_transpose (C, M, accum, A, desc)\nDimensions not compatible:\noutput is 3-by-2\ninput is 2-by-3\n'
```