### PR TITLE
Fix dimensions in operations mxv and vxm, check descriptors

### DIFF
--- a/pygraphblas/matrix.py
+++ b/pygraphblas/matrix.py
@@ -761,7 +761,7 @@ class Matrix:
 
         """
         if out is None:
-            out = Vector.from_type(self.type, self.ncols)
+            out = Vector.from_type(self.type, self.nrows)
         mask, semiring, accum, desc = self._get_args(**kwargs)
         _check(lib.GrB_mxv(
             out.vector[0],

--- a/pygraphblas/matrix.py
+++ b/pygraphblas/matrix.py
@@ -761,7 +761,9 @@ class Matrix:
 
         """
         if out is None:
-            out = Vector.from_type(self.type, self.nrows)
+            new_dimension = self.ncols if TransposeA in kwargs.get('desc', ()) \
+                else self.nrows
+            out = Vector.from_type(self.type, new_dimension)
         mask, semiring, accum, desc = self._get_args(**kwargs)
         _check(lib.GrB_mxv(
             out.vector[0],

--- a/pygraphblas/vector.py
+++ b/pygraphblas/vector.py
@@ -21,7 +21,7 @@ from .binaryop import BinaryOp, current_accum, current_binop
 from .unaryop import UnaryOp
 from .monoid import Monoid, current_monoid
 from . import descriptor
-from .descriptor import Descriptor, Default, TransposeA
+from .descriptor import Descriptor, Default, TransposeB
 
 __all__ = ['Vector']
 
@@ -342,7 +342,9 @@ class Vector:
         """
         from .matrix import Matrix
         if out is None:
-            out = Vector.from_type(self.type, self.size)
+            new_dimension = other.nrows if TransposeB in desc \
+                else other.ncols
+            out = Vector.from_type(self.type, new_dimension)
         elif not isinstance(out, Vector):
             raise TypeError('Output argument must be Vector.')
         if isinstance(mask, Vector):

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -232,6 +232,8 @@ def test_mxv():
 
     assert o.iseq(m @ v)
 
+    assert o.iseq(m.transpose().mxv(v, desc=descriptor.TransposeA))
+
 def test_matrix_pattern():
     v = Matrix.from_lists(
         list(range(10)),

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -219,16 +219,16 @@ def test_mxm():
 
 def test_mxv():
     m = Matrix.from_lists(
-        [0,1,2],
-        [1,2,0],
-        [1,2,3])
+        [0,1,2,3],
+        [1,2,0,1],
+        [1,2,3,4])
     v = Vector.from_lists(
         [0,1,2],
         [2,3,4])
     o = m.mxv(v)
     assert o == Vector.from_lists(
-        [0, 1, 2],
-        [3, 8, 6])
+        [0, 1, 2, 3],
+        [3, 8, 6, 12])
 
     assert m @ v == o
 

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -226,11 +226,11 @@ def test_mxv():
         [0,1,2],
         [2,3,4])
     o = m.mxv(v)
-    assert o == Vector.from_lists(
+    assert o.iseq(Vector.from_lists(
         [0, 1, 2, 3],
-        [3, 8, 6, 12])
+        [3, 8, 6, 12]))
 
-    assert m @ v == o
+    assert o.iseq(m @ v)
 
 def test_matrix_pattern():
     v = Matrix.from_lists(

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -185,22 +185,25 @@ def test_vector_assign():
 
 def test_vxm():
     m = Matrix.from_lists(
-        [0, 1, 2],
-        [1, 2, 0],
-        [1, 2, 3])
+        [0, 1, 2, 0],
+        [1, 2, 0, 3],
+        [1, 2, 3, 4])
     v = Vector.from_lists(
         [0, 1, 2],
         [2, 3, 4])
     o = v.vxm(m)
     assert o.iseq(Vector.from_lists(
-        [0, 1, 2],
-        [12, 2, 6]))
-
-    w = Vector.dup(v)
+        [ 0, 1, 2, 3],
+        [12, 2, 6, 8]))
 
     assert (v @ m).iseq(o)
-    # v @= m
-    # assert v.iseq(o)
+
+    assert v.vxm(m.transpose(), desc=TransposeB).iseq(o)
+
+    # m2 = m[:, :2]
+    # v2 = v.dup()
+    # v2 @= m2
+    # assert v2.iseq(o[:2])
 
 def test_apply():
     v = Vector.from_lists(


### PR DESCRIPTION
This PR
- fixes dimensions used in operations mxv and vxm,
- checks descriptor parameters,
- modifies tests to use non-square matrices.