### PR TITLE
Fix mask for element-wise vector operations

### DIFF
--- a/pygraphblas/vector.py
+++ b/pygraphblas/vector.py
@@ -276,6 +276,8 @@ class Vector:
             add_op = _get_bin_op(add_op, self.type)
         if isinstance(add_op, BinaryOp):
             add_op = add_op.get_binaryop(self, other)
+        if isinstance(mask, Vector):
+            mask = mask.vector[0]
         if accum is NULL:
             accum = current_accum.get(NULL)
         if isinstance(accum, BinaryOp):
@@ -316,6 +318,8 @@ class Vector:
             mult_op = _get_bin_op(mult_op, self.type)
         if isinstance(mult_op, BinaryOp):
             mult_op = mult_op.get_binaryop(self, other)
+        if isinstance(mask, Vector):
+            mask = mask.vector[0]
         if accum is NULL:
             accum = current_accum.get(NULL)
         if isinstance(accum, BinaryOp):


### PR DESCRIPTION
@michelp in the element-wise operations, vectors did not extract the `.vector[0]` field from the mask which caused the following error:
```python
a = Vector.from_type(UINT64, 3)
b = Vector.from_type(UINT64, 3)
c = Vector.from_type(UINT64, 3)
x = a.emult(b, mask=c)
```
```console
TypeError: initializer for ctype 'struct GB_Vector_opaque *' must be a cdata pointer, not Vector
```
This PR fixes the problem.