### PR TITLE
Type-related patches

### DIFF
--- a/pygraphblas/matrix.py
+++ b/pygraphblas/matrix.py
@@ -615,13 +615,14 @@ class Matrix:
         """
         if out is None:
             out = self.__class__.from_type(self.type, self.nrows, self.ncols)
-        nop = op.get_unaryop(self)
+        if isinstance(op, UnaryOp):
+            op = op.get_unaryop(self)
         mask, semiring, accum, desc = self._get_args(**kwargs)
         _check(lib.GrB_Matrix_apply(
             out.matrix[0],
             mask,
             accum,
-            nop,
+            op,
             self.matrix[0],
             desc
             ))

--- a/pygraphblas/matrix.py
+++ b/pygraphblas/matrix.py
@@ -37,7 +37,13 @@ class Matrix:
 
     __slots__ = ('matrix', 'type', '_funcs', '_keep_alives')
 
-    def __init__(self, matrix, typ, **options):
+    def __init__(self, matrix, typ=None, **options):
+        if typ is None:
+            new_type = ffi.new('GrB_Type*')
+            _check(lib.GxB_Matrix_type(new_type, matrix[0]))
+
+            typ = types.gb_type_to_type(new_type[0])
+
         self.matrix = matrix
         self.type = typ
         self._keep_alives = weakref.WeakKeyDictionary()
@@ -113,9 +119,7 @@ class Matrix:
         """
         m = ffi.new('GrB_Matrix*')
         _check(lib.LAGraph_binread(m, bin_file))
-        new_type = ffi.new('GrB_Type*')
-        _check(lib.GxB_Matrix_type(new_type, m[0]))
-        return cls(m, types.gb_type_to_type(new_type[0]))
+        return cls(m)
 
     @classmethod
     def from_random(cls, typ, nrows, ncols, nvals,

--- a/pygraphblas/vector.py
+++ b/pygraphblas/vector.py
@@ -484,7 +484,7 @@ class Vector:
         if out is None:
             out = Vector.from_type(self.type, self.size)
         if isinstance(op, UnaryOp):
-            op = op.unaryop
+            op = op.get_unaryop(self)
 
         mask, monoid, accum, desc = self._get_args(**kwargs)
         _check(lib.GrB_Vector_apply(

--- a/pygraphblas/vector.py
+++ b/pygraphblas/vector.py
@@ -34,7 +34,13 @@ class Vector:
 
     __slots__ = ('vector', 'type', '_keep_alives')
 
-    def __init__(self, vec, typ):
+    def __init__(self, vec, typ=None):
+        if typ is None:
+            new_type = ffi.new('GrB_Type*')
+            _check(lib.GxB_Vector_type(new_type, vec[0]))
+
+            typ = types.gb_type_to_type(new_type[0])
+
         self.vector = vec
         self.type = typ
         self._keep_alives = weakref.WeakKeyDictionary()

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -490,6 +490,12 @@ def test_apply():
         [0, 1, 2],
         [0, 1, 2],
         [-2, -3, -4]))
+    
+    w2 = v.apply(unaryop.AINV)
+    assert w.iseq(w2)
+    
+    w3 = v.apply(lib.GrB_AINV_INT64)
+    assert w.iseq(w3)
 
 def test_get_set_options():
     v = Matrix.from_random(INT8, 10, 10, 10, seed=42)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -6,7 +6,18 @@ import re
 import pytest
 
 from pygraphblas import *
-from pygraphblas.base import lib
+from pygraphblas.base import lib, _check
+
+
+def test_matrix_init_without_type():
+    mx = Matrix.from_type(INT8)
+
+    # get a raw Matrix pointer and wrap it without knowing its type
+    new_mx = ffi.new('GrB_Matrix*')
+    _check(lib.GrB_Matrix_dup(new_mx, mx.matrix[0]))
+    mx2 = Matrix(new_mx)
+
+    assert mx.type == mx2.type
 
 def test_matrix_create_from_type():
     m = Matrix.from_type(INT8)

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -4,6 +4,18 @@ from array import array
 import re
 
 from pygraphblas import *
+from pygraphblas.base import _check
+
+
+def test_vector_init_without_type():
+    vec = Vector.from_type(INT8)
+
+    # get a raw Vector pointer and wrap it without knowing its type
+    new_vec = ffi.new('GrB_Vector*')
+    _check(lib.GrB_Vector_dup(new_vec, vec.vector[0]))
+    vec2 = Vector(new_vec)
+
+    assert vec.type == vec2.type
 
 def test_vector_create_from_type():
     m = Vector.from_type(INT64)

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -224,6 +224,12 @@ def test_apply():
         [0, 1, 2],
         [-2.0, -4.0, -8.0]))
 
+    w2 = v.apply(unaryop.AINV)
+    assert w.iseq(w2)
+
+    w3 = v.apply(lib.GrB_AINV_INT64)
+    assert w.iseq(w3)
+
     w = ~v
     assert w.iseq(Vector.from_lists(
         [0, 1, 2],


### PR DESCRIPTION
This PR adds the following:
- Enable using raw and type-independent operators in Matrix/Vector.apply(), add tests
- Determine type parameter in Matrix/Vector constructor when absent