### PR TITLE
Fix use of CMake flags in Dockerfile-notebook and in Ubuntu install script

### DIFF
--- a/Dockerfile-notebook
+++ b/Dockerfile-notebook
@@ -34,10 +34,11 @@ ARG SS_COMPACT=0
 # get GraphBLAS, compile with debug symbols
 
 RUN git clone  --branch ${SS_RELEASE} --single-branch https://github.com/DrTimothyAldenDavis/GraphBLAS.git && \
-     cd GraphBLAS && \
-    make library JOBS=4 CFLAGS="-DGB_BURBLE=${SS_BURBLE} -DGBCOMPACT=${SS_COMPACT}"  \
-    && make install
-RUN cd .. && /bin/rm -Rf GraphBLAS
+     cd GraphBLAS/build && \
+     cmake .. -DGB_BURBLE=${SS_BURBLE} -DGBCOMPACT=${SS_COMPACT} && \
+     make -j4 && \
+     make install
+RUN cd ../.. && /bin/rm -Rf GraphBLAS
 
 RUN conda install -y graphviz
 

--- a/install-ubuntu.sh
+++ b/install-ubuntu.sh
@@ -8,16 +8,16 @@ sudo apt install -y curl m4 g++
 
 # Install the required version of SuiteSparse:GraphBLAS
 
-SS_RELEASE=v3.2.0
-GB_BURBLE=0
-GBCOMPACT=0
-export JOBS=$(nproc) # use all threads for compiling
+SS_RELEASE=v3.2.2
+SS_BURBLE=0
+SS_COMPACT=0
 
-git clone  --branch ${SS_RELEASE} --single-branch https://github.com/DrTimothyAldenDavis/GraphBLAS.git
-cd GraphBLAS
-make library CFLAGS="-DGB_BURBLE=${GB_BURBLE} -DGBCOMPACT=${GBCOMPACT}"
+git clone --branch ${SS_RELEASE} --single-branch https://github.com/DrTimothyAldenDavis/GraphBLAS.git
+cd GraphBLAS/build
+cmake .. -DGB_BURBLE=${SS_BURBLE} -DGBCOMPACT=${SS_COMPACT}
+make -j$(nproc)
 sudo make install
-cd ..
+cd ../..
 
 # Install Python components
 sudo apt install -y python3-pip


### PR DESCRIPTION
I had suspiciously quick (<2 minutes) GrB builds on my laptop even when the `COMPACT` flag was turned off. This is not a problem in day-to-day prototyping but becomes an issue when one tries to benchmark the performance of pygrb-based implementations.

The cause of the problem is that
```bash
make CFLAGS="-DGB_BURBLE=${SS_BURBLE} -DGBCOMPACT=${SS_COMPACT}"
```
does not pass the arguments correctly. Instead, one needs to use:
```bash
cmake .. -DGB_BURBLE=${SS_BURBLE} -DGBCOMPACT=${SS_COMPACT} && make
```

I did this change in the Ubuntu install script and `Dockerfile-notebook`, and also bumped GrB to v3.2.2 (as v3.2.0 does not have the `GBCOMPACT` flag).

Please review @michelp @marci543 