### PR TITLE
Fix the link to the LAGraph PageRank implentation

### DIFF
--- a/pygraphblas/demo/PageRank.ipynb
+++ b/pygraphblas/demo/PageRank.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "## PageRank\n",
     "\n",
-    "This is a translation of the [PageRank function](https://github.com/GraphBLAS/LAGraph/blob/master/Source/Algorithm/LAGraph_bc_batch4.c) for the GAP Benchmark work done by Dr. Tim Davis at TAMU.\n",
+    "This is a translation of the [PageRank function](https://github.com/GraphBLAS/LAGraph/blob/master/Source/Algorithm/LAGraph_pagerank3a.c) for the GAP Benchmark work done by Dr. Tim Davis at TAMU.\n",
     "\n",
     "\"PageRank works by counting the number and quality of links to a page to determine a rough estimate of how important the website is. The underlying assumption is that more important websites are likely to receive more links from other websites.\" - <https://en.wikipedia.org/wiki/PageRank>"
    ]


### PR DESCRIPTION
Just a minor doc-fix.
previous link lead to a `betweeness centrality` implementation