### PR TITLE
fix: incompatible suitesparse version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     install_requires=[
         "numpy<1.21",
         "numba",
-        "suitesparse-graphblas",
+        "suitesparse-graphblas<6.1.4",
         "scipy",
         "contextvars",
         "mmparse",


### PR DESCRIPTION
Currently-published suitesparse-graphblas wheels for 6.1.5 are built against an incompatible numpy:

```
$ python -c "from suitesparse_graphblas import utils"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/seb/.pyenv/versions/3.8.12/envs/python-graphblas-test/lib/python3.8/site-packages/suitesparse_graphblas/__init__.py", line 3, in <module>
    from . import utils
  File "suitesparse_graphblas/utils.pyx", line 1, in init suitesparse_graphblas.utils
ValueError: numpy.ufunc size changed, may indicate binary incompatibility. Expected 232 from C header, got 216 from PyObject
```